### PR TITLE
fix order history endpoint security issue

### DIFF
--- a/Api/GuestOrderHistoryInformationInterface.php
+++ b/Api/GuestOrderHistoryInformationInterface.php
@@ -12,12 +12,10 @@ interface GuestOrderHistoryInformationInterface
     /**
      * Getter for order history array
      *
-     * @param string $email
-     * @param string $phone
+     * @param string $cartId
      * @return string
      */
     public function getOrderHistory(
-        $email,
-        $phone = null
+        $cartId
     );
 }

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -14,13 +14,7 @@
             <resource ref="anonymous" />
         </resources>
     </route>
-    <route url="/V1/guest-carts/:cartId/order-history/:email" method="GET">
-        <service class="Tabby\Checkout\Api\GuestOrderHistoryInformationInterface" method="getOrderHistory" />
-        <resources>
-            <resource ref="anonymous" />
-        </resources>
-    </route>
-    <route url="/V1/guest-carts/:cartId/order-history/:email/:phone" method="GET">
+    <route url="/V1/guest-carts/:cartId/order-history/" method="GET">
         <service class="Tabby\Checkout\Api\GuestOrderHistoryInformationInterface" method="getOrderHistory" />
         <resources>
             <resource ref="anonymous" />

--- a/view/frontend/web/js/model/tabby_checkout.js
+++ b/view/frontend/web/js/model/tabby_checkout.js
@@ -136,10 +136,8 @@ define(
 
                     fullScreenLoader.startLoader();
                     storage.get(
-                        UrlBuilder.createUrl('/guest-carts/:cartId/order-history/:email/:phone', {
-                            cartId: Quote.getQuoteId(),
-                            email: this.email,
-                            phone: this.phone
+                        UrlBuilder.createUrl('/guest-carts/:cartId/order-history/', {
+                            cartId: Quote.getQuoteId()
                         })
                     ).done(function (response) {
                         fullScreenLoader.stopLoader();


### PR DESCRIPTION
this endpoint do not check the cart id, and anyone can put any customer email to get list of orders placed by this customer
/V1/guest-carts/:cartId/order-history/:email/
/V1/guest-carts/:cartId/order-history/:email/:phone

this expose security risk of access sensitive information of other clients.
this endpoint does not compare quote email with provided email.

as a solution we have to remove email and phone from endpoint because they can be retrieved from provided cart
new endpoint
/V1/guest-carts/:cartId/order-history/
![image](https://github.com/user-attachments/assets/b1f228cc-1303-4040-bc23-7c8ac6d6a11c)
